### PR TITLE
Require less of bootstrap-vue

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -3,10 +3,10 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 
 var axios = require('axios');
-var bootstrapVue = require('bootstrap-vue');
 var Vue = require('vue');
 var VueRouter = require('vue-router');
 var Vuex = require('vuex');
+var bootstrapVue = require('bootstrap-vue');
 
 function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 
@@ -259,25 +259,25 @@ class EventService {
 
     set app(app) {
         if (!app.$bvToast) {
-            Vue__default['default'].use(bootstrapVue.ToastPlugin);
+            console.warn('vue toast plugin missing, make sure to import it');
         }
 
         if (!app.$bvModal) {
-            Vue__default['default'].user(bootstrapVue.ModalPlugin);
+            console.warn('vue modal plugin missing, make sure to import it');
         }
         this._app = app;
     }
 
     /** @returns {ResponseMiddleware} */
     get responseMiddleware() {
-        return ({data}) => {
+        return ({ data }) => {
             if (data && data.message) this.successToast(data.message);
         };
     }
 
     /** @returns {ResponseErrorMiddleware} */
     get responseErrorMiddleware() {
-        return ({response}) => {
+        return ({ response }) => {
             if (response && response.data.message) this.dangerToast(response.data.message);
         };
     }
@@ -1241,7 +1241,9 @@ class StoreModuleFactory {
                         const newData = allData.splice(newDataIndex, 1)[0];
 
                         // if the entry for this id is larger then the current entry, do nothing
-                        if (Object.values(state[stateName][id]).length > Object.values(newData).length) continue;
+                        
+                        if ((state[stateName][id] != null) && 
+                            (Object.values(state[stateName][id]).length > Object.values(newData).length)) continue;
 
                         Vue__default['default'].set(state[stateName], newData.id, newData);
                     }
@@ -2658,7 +2660,7 @@ class EditPageCreator {
                 },
             },
             data() {
-                return {editable: {}};
+                return { editable: {} };
             },
             render(h) {
                 // TODO :: notFoundMessage should be clear
@@ -2670,14 +2672,12 @@ class EditPageCreator {
                 ];
 
                 if (destroyAction) {
-                    // TODO :: move to method, when there are more b-links
-                    // TODO :: uses Bootstrap-Vue element
                     containerChildren.push(
                         h(
-                            'b-link',
+                            'a',
                             {
-                                class: 'text-danger',
-                                on: {click: destroyAction},
+                                class: 'btn btn-outline-danger mt-2',
+                                on: { click: destroyAction },
                             },
                             [`${pageCreator._translatorService.getCapitalizedSingular(subject)} verwijderen`]
                         )
@@ -2732,14 +2732,14 @@ class EditPageCreator {
      * @param {(item:Object<string,any) => void} action
      */
     createForm(form, editable, action) {
-        return this._h('div', {class: 'row mt-3'}, [
+        return this._h('div', { class: 'row mt-3' }, [
             this._baseCreator.col([
                 this._h(form, {
                     props: {
                         editable,
                         errors: this._errorService.getErrors(),
                     },
-                    on: {submit: () => action(editable)},
+                    on: { submit: () => action(editable) },
                 }),
             ]),
         ]);

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
-import { ToastPlugin, ModalPlugin, BTable } from 'bootstrap-vue';
 import Vue from 'vue';
 import VueRouter from 'vue-router';
 import Vuex from 'vuex';
+import { BTable } from 'bootstrap-vue';
 
 const keepALiveKey = 'keepALive';
 /** setting keepALive here so we don't have to Parse it each time we get it */
@@ -248,25 +248,25 @@ class EventService {
 
     set app(app) {
         if (!app.$bvToast) {
-            Vue.use(ToastPlugin);
+            console.warn('vue toast plugin missing, make sure to import it');
         }
 
         if (!app.$bvModal) {
-            Vue.user(ModalPlugin);
+            console.warn('vue modal plugin missing, make sure to import it');
         }
         this._app = app;
     }
 
     /** @returns {ResponseMiddleware} */
     get responseMiddleware() {
-        return ({data}) => {
+        return ({ data }) => {
             if (data && data.message) this.successToast(data.message);
         };
     }
 
     /** @returns {ResponseErrorMiddleware} */
     get responseErrorMiddleware() {
-        return ({response}) => {
+        return ({ response }) => {
             if (response && response.data.message) this.dangerToast(response.data.message);
         };
     }
@@ -1230,7 +1230,9 @@ class StoreModuleFactory {
                         const newData = allData.splice(newDataIndex, 1)[0];
 
                         // if the entry for this id is larger then the current entry, do nothing
-                        if (Object.values(state[stateName][id]).length > Object.values(newData).length) continue;
+                        
+                        if ((state[stateName][id] != null) && 
+                            (Object.values(state[stateName][id]).length > Object.values(newData).length)) continue;
 
                         Vue.set(state[stateName], newData.id, newData);
                     }
@@ -2647,7 +2649,7 @@ class EditPageCreator {
                 },
             },
             data() {
-                return {editable: {}};
+                return { editable: {} };
             },
             render(h) {
                 // TODO :: notFoundMessage should be clear
@@ -2659,14 +2661,12 @@ class EditPageCreator {
                 ];
 
                 if (destroyAction) {
-                    // TODO :: move to method, when there are more b-links
-                    // TODO :: uses Bootstrap-Vue element
                     containerChildren.push(
                         h(
-                            'b-link',
+                            'a',
                             {
-                                class: 'text-danger',
-                                on: {click: destroyAction},
+                                class: 'btn btn-outline-danger mt-2',
+                                on: { click: destroyAction },
                             },
                             [`${pageCreator._translatorService.getCapitalizedSingular(subject)} verwijderen`]
                         )
@@ -2721,14 +2721,14 @@ class EditPageCreator {
      * @param {(item:Object<string,any) => void} action
      */
     createForm(form, editable, action) {
-        return this._h('div', {class: 'row mt-3'}, [
+        return this._h('div', { class: 'row mt-3' }, [
             this._baseCreator.col([
                 this._h(form, {
                     props: {
                         editable,
                         errors: this._errorService.getErrors(),
                     },
-                    on: {submit: () => action(editable)},
+                    on: { submit: () => action(editable) },
                 }),
             ]),
         ]);

--- a/src/creators/editpagecreator.js
+++ b/src/creators/editpagecreator.js
@@ -55,7 +55,7 @@ export class EditPageCreator {
                 },
             },
             data() {
-                return {editable: {}};
+                return { editable: {} };
             },
             render(h) {
                 // TODO :: notFoundMessage should be clear
@@ -67,14 +67,12 @@ export class EditPageCreator {
                 ];
 
                 if (destroyAction) {
-                    // TODO :: move to method, when there are more b-links
-                    // TODO :: uses Bootstrap-Vue element
                     containerChildren.push(
                         h(
-                            'b-link',
+                            'a',
                             {
-                                class: 'text-danger',
-                                on: {click: destroyAction},
+                                class: 'btn btn-outline-danger mt-2',
+                                on: { click: destroyAction },
                             },
                             [`${pageCreator._translatorService.getCapitalizedSingular(subject)} verwijderen`]
                         )
@@ -129,14 +127,14 @@ export class EditPageCreator {
      * @param {(item:Object<string,any) => void} action
      */
     createForm(form, editable, action) {
-        return this._h('div', {class: 'row mt-3'}, [
+        return this._h('div', { class: 'row mt-3' }, [
             this._baseCreator.col([
                 this._h(form, {
                     props: {
                         editable,
                         errors: this._errorService.getErrors(),
                     },
-                    on: {submit: () => action(editable)},
+                    on: { submit: () => action(editable) },
                 }),
             ]),
         ]);

--- a/src/services/event/index.js
+++ b/src/services/event/index.js
@@ -5,9 +5,6 @@
  * @typedef {import('../http').ResponseErrorMiddleware} ResponseErrorMiddleware
  */
 
-import {ToastPlugin, ModalPlugin} from 'bootstrap-vue';
-import Vue from 'vue';
-
 export class EventService {
     /**
      *
@@ -27,25 +24,25 @@ export class EventService {
 
     set app(app) {
         if (!app.$bvToast) {
-            Vue.use(ToastPlugin);
+            console.warn('vue toast plugin missing, make sure to import it');
         }
 
         if (!app.$bvModal) {
-            Vue.user(ModalPlugin);
+            console.warn('vue modal plugin missing, make sure to import it');
         }
         this._app = app;
     }
 
     /** @returns {ResponseMiddleware} */
     get responseMiddleware() {
-        return ({data}) => {
+        return ({ data }) => {
             if (data && data.message) this.successToast(data.message);
         };
     }
 
     /** @returns {ResponseErrorMiddleware} */
     get responseErrorMiddleware() {
-        return ({response}) => {
+        return ({ response }) => {
             if (response && response.data.message) this.dangerToast(response.data.message);
         };
     }


### PR DESCRIPTION
- Remove requirement to have <b-link> defined
- Remove ToastPlugin & ModalPlugin imports making it possible to abstract `popper.js` from the main bundle. These imports are now warnings in the console.